### PR TITLE
Annotate native modules with @ReactModule and NAME constants

### DIFF
--- a/DirectionsRendererModule.java
+++ b/DirectionsRendererModule.java
@@ -30,6 +30,7 @@ import com.mapsindoors.core.errors.MIError;
 import com.mapsindoors.core.errors.MIErrorEnum;
 import com.mapsindoors.core.errors.MapsIndoorsException;
 import com.mapsindoorsrn.core.models.BitmapStopIconConfig;
+import com.facebook.react.module.annotations.ReactModule;
 import com.mapsindoorsrn.core.models.MPError;
 import com.mapsindoorsrn.core.models.RouteStopIconConfigModel;
 
@@ -41,7 +42,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
+@ReactModule(name = DirectionsRendererModule.NAME)
 public class DirectionsRendererModule extends ReactContextBaseJavaModule implements OnMapControlReadyListener {
+    public static final String NAME = "DirectionsRenderer";
+
     private MapControl mMapControl;
     private MPDirectionsRenderer mRenderer;
     private final ReactApplicationContext mCtx;
@@ -57,7 +61,7 @@ public class DirectionsRendererModule extends ReactContextBaseJavaModule impleme
     @NonNull
     @Override
     public String getName() {
-        return "DirectionsRenderer";
+        return NAME;
     }
 
     private void rejectPromise(Promise promise) {

--- a/DirectionsServiceModule.java
+++ b/DirectionsServiceModule.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.module.annotations.ReactModule;
 import com.google.gson.Gson;
 import com.mapsindoors.core.MPDirectionsService;
 import com.mapsindoors.core.MPPoint;
@@ -20,7 +21,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
+@ReactModule(name = DirectionsServiceModule.NAME)
 public class DirectionsServiceModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "DirectionsService";
 
     private HashMap<String, MPDirectionsService> serviceMap = new HashMap<>();
     private static final String NO_DS = "This DirectionsService is not available";
@@ -31,7 +34,7 @@ public class DirectionsServiceModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void create(final Promise promise) {
+    public void createService(final Promise promise) {
         MPDirectionsService service = new MPDirectionsService();
         String uuid = UUID.randomUUID().toString();
         serviceMap.put(uuid, service);
@@ -161,6 +164,6 @@ public class DirectionsServiceModule extends ReactContextBaseJavaModule {
     @NonNull
     @Override
     public String getName() {
-        return "DirectionsService";
+        return NAME;
     }
 }

--- a/MPDisplayRuleModule.java
+++ b/MPDisplayRuleModule.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.google.gson.Gson;
 import com.mapsindoors.core.MPBadgePosition;
 import com.mapsindoors.core.MPDisplayRule;
@@ -20,7 +21,10 @@ import com.mapsindoors.core.errors.MIError;
 import com.mapsindoors.core.errors.MIErrorEnum;
 import com.mapsindoorsrn.core.models.MPError;
 
+@ReactModule(name = MPDisplayRuleModule.NAME)
 public class MPDisplayRuleModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "DisplayRule";
+
     private final Gson gson = new Gson();
 
     public MPDisplayRuleModule(@NonNull ReactApplicationContext reactContext) {
@@ -30,7 +34,7 @@ public class MPDisplayRuleModule extends ReactContextBaseJavaModule {
     @NonNull
     @Override
     public String getName() {
-        return "DisplayRule";
+        return NAME;
     }
 
     private void reject(Promise promise, String id) {

--- a/MapControlModule.java
+++ b/MapControlModule.java
@@ -42,6 +42,7 @@ import com.mapsindoors.core.models.MPMapStyle;
 import com.mapsindoorsrn.core.models.Filter;
 import com.mapsindoorsrn.core.models.Location;
 import com.mapsindoorsrn.core.models.MPCameraUpdate;
+import com.facebook.react.module.annotations.ReactModule;
 import com.mapsindoorsrn.core.models.MPError;
 
 import java.util.ArrayList;
@@ -49,7 +50,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@ReactModule(name = MapControlModule.NAME)
 public class MapControlModule extends ReactContextBaseJavaModule implements MPCameraEventListener, OnFloorUpdateListener, MPFloorSelectorInterface {
+    public static final String NAME = "MapControlModule";
+
     private RCMapView mMapView;
     private final Gson gson = new Gson();
     private MapControl mMapControl;
@@ -64,7 +68,7 @@ public class MapControlModule extends ReactContextBaseJavaModule implements MPCa
     @NonNull
     @Override
     public String getName() {
-        return "MapControlModule";
+        return NAME;
     }
 
     private void reject(Promise promise, MIError error) {

--- a/MapsIndoorsModule.java
+++ b/MapsIndoorsModule.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.module.annotations.ReactModule;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.mapsindoors.core.MPBuilding;
@@ -39,7 +40,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@ReactModule(name = MapsIndoorsModule.NAME)
 public class MapsIndoorsModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "MapsIndoorsModule";
 
     private final ReactApplicationContext reactContext;
     private final Gson gson = new Gson();
@@ -53,7 +56,7 @@ public class MapsIndoorsModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "MapsIndoorsModule";
+        return NAME;
     }
 
     private void reject(Promise promise, MIError error) {

--- a/UtilsModule.java
+++ b/UtilsModule.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
 import com.google.gson.Gson;
 import com.mapsindoors.core.MPCollisionHandling;
 import com.mapsindoors.core.MPGeometry;
@@ -25,7 +26,9 @@ import com.mapsindoorsrn.core.models.MPError;
 
 import java.util.Locale;
 
+@ReactModule(name = UtilsModule.NAME)
 public class UtilsModule extends ReactContextBaseJavaModule {
+    public static final String NAME = "UtilsModule";
 
     private final Gson gson = new Gson();
 
@@ -36,7 +39,7 @@ public class UtilsModule extends ReactContextBaseJavaModule {
     @NonNull
     @Override
     public String getName() {
-        return "UtilsModule";
+        return NAME;
     }
 
     private void reject(Promise promise, MIError error) {


### PR DESCRIPTION
Add @ReactModule annotations and NAME constants to all native module classes for explicit module registration. Rename DirectionsService's create method to createService to avoid naming collision.